### PR TITLE
fix: update contact link to point to the correct URL

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -144,7 +144,7 @@ export function Navbar() {
                   asChild
                   className="w-full bg-yellow hover:bg-yellow-600 text-primary font-semibold"
                 >
-                  <Link href="/contact">
+                  <Link href="/contact-us">
                     Contact Us
                   </Link>
                 </Button>


### PR DESCRIPTION
This pull request updates the navigation link in the `Navbar` component to point to the correct contact page route.

* Updated the `Navbar` component in `app/components/Navbar.tsx` so that the "Contact Us" button now links to `/contact-us` instead of `/contact`.